### PR TITLE
Add .star as starlark file extension

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1914,7 +1914,7 @@ source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569
 [[language]]
 name = "starlark"
 scope = "source.starlark"
-injection-regex = "(starlark|bzl|bazel)"
+injection-regex = "(starlark|star|bzl|bazel)"
 file-types = ["bzl", "bazel", "BUILD"]
 roots = []
 comment-token = "#"


### PR DESCRIPTION
In addition to the other defined extensions, `.star` is a frequently used extension for starlark files. This can be demonstrated through a cursory search of github for files ending in `.star`: https://github.com/search?q=path%3A%2F.star%24%2F&type=code